### PR TITLE
Update ch15_1_pdfparanoia.py

### DIFF
--- a/ch15_1_pdfparanoia.py
+++ b/ch15_1_pdfparanoia.py
@@ -1,27 +1,30 @@
 '''
-Encrypt all pdfs in a folder
-Next (to do): Include files in subfolder too
-Next 2: Decrypt them
+Create encrypted copies of all pdfs in a folder. Include all files in subfolders.
+If PDfs exist in target location, they will be over-written.
 '''
 
-import PyPDF2, os
+import PyPDF2, os.path
 
-folder_location = 'C:/Python/Automate the Boring Stuff 2e/PDF stack/' # replace with actual folder path
-for folder_name, subfolders, filenames in os.walk(folder_location):
-    for j in filenames:
-        pdf_reader = PyPDF2.PdfFileReader(open(folder_location + j, 'rb'))
+# File paths of PDFs to be copied from and to. End file path with '/'
+folder_location = 'C:/Users/.../Automate the Boring Stuff 2e/PDF stack/' # Use your local file path
+target_location = 'C:/Users/.../Automate the Boring Stuff 2e/Encrypted Stack/' # Use your local file path
+
+for path, subfolders, files in os.walk(folder_location):
+    for i in files:
+        # print("File inside %r" % (path) + i)
+        # Use 'path', not 'subfolders', for PdfFileReader file location
+        pdf_reader = PyPDF2.PdfFileReader(open(path + '/' + i, 'rb'))
         # Start up PDF Writer Object
         pdf_writer = PyPDF2.PdfFileWriter()
         # Copy all reader pages to writer object using .addPage
         for page_num in range(pdf_reader.numPages):
             pdf_writer.addPage(pdf_reader.getPage(page_num))
-        # Set pasword
+        # Set password
         pdf_writer.encrypt('dayoldcroissant')
         # Create result PDF shell
-        result_pdf = open(folder_location + j + '_encrypted', 'wb')
+        print(target_location + i + '_encrypted', 'wb')
+        result_pdf = open(target_location + i + '_encrypted', 'wb')
         # Write to it
         pdf_writer.write(result_pdf)
         # Close it
         result_pdf.close()
-
-    print('THE END')


### PR DESCRIPTION
Before, this code didn't pick up and copy files in any subfolders, worked for files in the main folder only.
Fixed code to work for files in subfolders, tested with 2 nested subfolders).

@rmogollanhh

Changes made:

1. os is a big library, importing just os.path is sufficient for use of os.walk()

2. Confirmed os.walk() goes through all files & subfolder files without need for nested loop for subfolders
[https://stackoverflow.com/questions/10989005/do-i-understand-os-walk-right](https://stackoverflow.com/questions/10989005/do-i-understand-os-walk-right)

3. Made dynamic file paths to read subfolder files from using using of 'path' instead of hard-coded 'folder_location' for pdf_reader = PyPDF2.PdfFileReader(open(path + '/' + i, 'rb'))

4. Created separate 'Encrypted PDFs' folder as target location for copied PDFs that is outside of the source PDF folder. This was causing issues otherwise with the row:
result_pdf = open(folder_location + j + '_encrypted', 'wb')